### PR TITLE
Fix for Sierra

### DIFF
--- a/application/GlkTextBufferWindow.m
+++ b/application/GlkTextBufferWindow.m
@@ -327,8 +327,8 @@
     [container setLayoutManager: layoutmanager];
     [layoutmanager addTextContainer: container];
     
-    textview = [[MyTextView alloc] initWithFrame: NSZeroRect];
-    [textview setTextContainer: container];
+    textview = [[MyTextView alloc] initWithFrame:NSMakeRect(0, 0, 0, 1000000) textContainer:container];
+
     [container setTextView: textview];
     
     [scrollview setDocumentView: textview];


### PR DESCRIPTION
This change makes Spatterlight function on macOS Sierra and seems to work fine on older systems as well.

Basically it changes the creation of the text view in a text buffer window to the initWithFrame:textContainer: method recommended by Apple when you want to create all the components yourself. 

See https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/TextUILayer/Tasks/CreateTextViewProg.html

and

https://developer.apple.com/library/content/documentation/TextFonts/Conceptual/CocoaTextArchitecture/TextSystemArchitecture/ArchitectureOverview.html#//apple_ref/doc/uid/TP40009459-CH7-CJBJHGAG

I guess there is some bug or deliberate change in Sierra which makes the automatically created text storage get in the way of the one we create programmatically.